### PR TITLE
setup upgrade fails

### DIFF
--- a/Setup/RatingSetup.php
+++ b/Setup/RatingSetup.php
@@ -85,6 +85,6 @@ class RatingSetup
     public function renameRatingAttribute($eavSetup)
     {
         $entity = ProductAttributeInterface::ENTITY_TYPE_CODE;
-        $eavSetup->updateAttribute($entity, 'rating_summary', ['attribute_code' => 'ratings_summary']);
+        $eavSetup->updateAttribute($entity, 'ratings_summary', ['attribute_code' => 'rating_summary']);
     }
 }


### PR DESCRIPTION
in magento 2.2 setup upgrade was failing on rename, the updateAttribute code where wrong way round.